### PR TITLE
Fixed early contracts parameters to be completeable

### DIFF
--- a/GameData/HistoricalContractPack/Contracts/Sounding/SoundingFirst.cfg
+++ b/GameData/HistoricalContractPack/Contracts/Sounding/SoundingFirst.cfg
@@ -41,17 +41,23 @@ CONTRACT_TYPE {
 			title = Uncrewed
 		}		
 		PARAMETER {
-			name = ReachStateFlying
-			type = ReachState
-			situation = FLYING
-			minRateOfClimb = 250
-		}
-   		PARAMETER {
-			name = ReachStateLaunch
-			type = ReachState
-			minAltitude = 25000
-			title = Reach 25 km
-			hideChildren = true
+			name = FlightParameters
+			type = VesselParameterGroup		
+			title = Attain mission parameters 
+			
+			PARAMETER {
+				name = ReachStateFlying
+				type = ReachState
+				situation = FLYING
+				minRateOfClimb = 250
+			}
+			PARAMETER {
+				name = ReachStateLaunch
+				type = ReachState
+				minAltitude = 25000
+				title = Reach 25 km
+				hideChildren = true
+			}
 		}
 		PARAMETER {
 			name = ReturnHome

--- a/GameData/HistoricalContractPack/Contracts/SoundingScience/SoundingBio.cfg
+++ b/GameData/HistoricalContractPack/Contracts/SoundingScience/SoundingBio.cfg
@@ -58,29 +58,50 @@ CONTRACT_TYPE {
 			hideChildren = true
 		}
 		PARAMETER {
-			name = SpaceAltitude
-			type = ReachState
-			minAltitude = @/altitude * 1000
-			disableOnStateChange = true
-			title = Reach an altitude of at least @/altitude km
+			name = PayloadMissionParameters
+			type = VesselParameterGroup		
+			title = Reach @/altitude km with the payload and run experiment for 60 seconds
+			duration = 1m
+			PARAMETER {
+				name = SpaceAltitude
+				type = ReachState
+				minAltitude = @/altitude * 1000
+				disableOnStateChange = true
+				title = Reach an altitude of at least @/altitude km
+			}
+			PARAMETER {
+				name = HasCommPayload
+				type = HasResource
+				resource = CommPayload
+				minQuantity = @/payload-0.1
+				title = Have a CommPayload of at least @/payload units on the craft
+				hideChildren = true
+				completeInSequence = true
+				disableOnStateChange = true
+			}
+			PARAMETER {
+				name = ExperimentRunning
+				type = ExperimentRunning
+				title = Run a small biological experiment (above @/altitude km)
+				experiment = RP0bioScan1
+				completeInSequence = true
+				disableOnStateChange = true
+			}
 		}
 		PARAMETER {
-			name = HasCommPayload
-			type = HasResource
-			resource = CommPayload
-			minQuantity = @/payload-0.1
-			title = Have a CommPayload of at least @/payload units on the craft
+			name = HasBiologicalSample
+			type = PartValidation
+			title = Recover the biological experiment safely
 			hideChildren = true
+			FILTER {
+				MODULE {
+					name = Experiment
+					experiment_id = RP0bioScan1
+				}
+			}
+			disableOnStateChange = true
 			completeInSequence = true
 		}
-		///PARAMETER {
-		///	name = ExperimentRunning
-		///	type = ExperimentRunning
-		///	title = Run a small biological experiment (above @/altitude km)
-		///	experiment = bioScan1
-		///	completeInSequence = true
-		///	disableOnStateChange = true
-		///}
 		PARAMETER {
 			name = ReturnHome
 			type = ReturnHome
@@ -89,20 +110,7 @@ CONTRACT_TYPE {
 			hideChildren = true
 			completeInSequence = true
 		}
-		PARAMETER {
-			name = HasBiologicalSample
-			type = PartValidation
-			title = Recover the biological experiment safely
-			FILTER {
-				MODULE {
-					name = Experiment
-					experiment_id = bioScan1
-				}
-			}
-			completeInSequence = true
-		}
 	}
-
 	PARAMETER
 	{
 		name = All
@@ -148,23 +156,50 @@ CONTRACT_TYPE {
 				hideChildren = true
 			}
 			PARAMETER {
-				name = SpaceAltitude
-				type = ReachState
-				minAltitude = @/altitude * 1000
-				disableOnStateChange = true
-			}
-			PARAMETER {
-				name = HasCommPayload
-				type = HasResource
-				resource = CommPayload
-				minQuantity = @/payload-0.1
+				name = PayloadMissionParameters
+				type = VesselParameterGroup		
+				title = Reach @/altitude km with the payload and run experiment for 60 seconds
+				duration = 1m
 				hideChildren = true
-				completeInSequence = true
+				PARAMETER {
+					name = SpaceAltitude
+					type = ReachState
+					minAltitude = @/altitude * 1000
+					hideChildren = true
+					disableOnStateChange = true
+					title = Reach an altitude of at least @/altitude km
+				}
+				PARAMETER {
+					name = HasCommPayload
+					type = HasResource
+					resource = CommPayload
+					minQuantity = @/payload-0.1
+					title = Have a CommPayload of at least @/payload units on the craft
+					hideChildren = true
+					completeInSequence = true
+					disableOnStateChange = true
+				}
+				PARAMETER {
+					name = ExperimentRunning
+					type = ExperimentRunning
+					title = Run a small biological experiment (above @/altitude km)
+					experiment = RP0bioScan1
+					completeInSequence = true
+					hideChildren = true
+				}
 			}
+			/// Disabled due to display issues - forcing the experiment means that you do not get science if you do not recover anyway
 			///PARAMETER {
-			///	name = ExperimentRunning
-			///	type = ExperimentRunning
-			///	experiment = bioScan1
+			///	name = HasBiologicalSample
+			///	type = PartValidation
+			///	hidden = true
+			///	hideChildren = true
+			///	FILTER {
+			///		MODULE {
+			///			name = Experiment
+			///			experiment_id = RP0bioScan1
+			///		}
+			///	}
 			///	completeInSequence = true
 			///	disableOnStateChange = true
 			///}
@@ -172,20 +207,8 @@ CONTRACT_TYPE {
 				name = ReturnHome
 				type = ReturnHome
 				targetBody = HomeWorld()
+				title = Return home safely
 				hideChildren = true
-				completeInSequence = true
-			}
-			PARAMETER {
-				name = HasBiologicalSample
-				type = PartValidation
-				hidden = true
-				hideChildren = true
-				FILTER {
-					MODULE {
-						name = Experiment
-						experiment_id = bioScan1
-					}
-				}
 				completeInSequence = true
 			}
 		}
@@ -230,23 +253,50 @@ CONTRACT_TYPE {
 				hideChildren = true
 			}
 			PARAMETER {
-				name = SpaceAltitude
-				type = ReachState
-				minAltitude = @/altitude * 1000
-				disableOnStateChange = true
-			}
-			PARAMETER {
-				name = HasCommPayload
-				type = HasResource
-				resource = CommPayload
-				minQuantity = @/payload-0.1
+				name = PayloadMissionParameters
+				type = VesselParameterGroup		
+				title = Reach @/altitude km with the payload and run experiment for 60 seconds
+				duration = 1m
 				hideChildren = true
-				completeInSequence = true
+				PARAMETER {
+					name = SpaceAltitude
+					type = ReachState
+					minAltitude = @/altitude * 1000
+					hideChildren = true
+					disableOnStateChange = true
+					title = Reach an altitude of at least @/altitude km
+				}
+				PARAMETER {
+					name = HasCommPayload
+					type = HasResource
+					resource = CommPayload
+					minQuantity = @/payload-0.1
+					title = Have a CommPayload of at least @/payload units on the craft
+					hideChildren = true
+					completeInSequence = true
+					disableOnStateChange = true
+				}
+				PARAMETER {
+					name = ExperimentRunning
+					type = ExperimentRunning
+					title = Run a small biological experiment (above @/altitude km)
+					experiment = RP0bioScan1
+					completeInSequence = true
+					hideChildren = true
+				}
 			}
+			/// Disabled due to display issues - forcing the experiment means that you do not get science if you do not recover anyway
 			///PARAMETER {
-			///	name = ExperimentRunning
-			///	type = ExperimentRunning
-			///	experiment = bioScan1
+			///	name = HasBiologicalSample
+			///	type = PartValidation
+			///	hidden = true
+			///	hideChildren = true
+			///	FILTER {
+			///		MODULE {
+			///			name = Experiment
+			///			experiment_id = RP0bioScan1
+			///		}
+			///	}
 			///	completeInSequence = true
 			///	disableOnStateChange = true
 			///}
@@ -254,20 +304,8 @@ CONTRACT_TYPE {
 				name = ReturnHome
 				type = ReturnHome
 				targetBody = HomeWorld()
+				title = Return home safely
 				hideChildren = true
-				completeInSequence = true
-			}
-			PARAMETER {
-				name = HasBiologicalSample
-				type = PartValidation
-				hidden = true
-				hideChildren = true
-				FILTER {
-					MODULE {
-						name = Experiment
-						experiment_id = bioScan1
-					}
-				}
 				completeInSequence = true
 			}
 		}
@@ -312,23 +350,50 @@ CONTRACT_TYPE {
 				hideChildren = true
 			}
 			PARAMETER {
-				name = SpaceAltitude
-				type = ReachState
-				minAltitude = @/altitude * 1000
-				disableOnStateChange = true
-			}
-			PARAMETER {
-				name = HasCommPayload
-				type = HasResource
-				resource = CommPayload
-				minQuantity = @/payload-0.1
+				name = PayloadMissionParameters
+				type = VesselParameterGroup		
+				title = Reach @/altitude km with the payload and run experiment for 60 seconds
+				duration = 1m
 				hideChildren = true
-				completeInSequence = true
+				PARAMETER {
+					name = SpaceAltitude
+					type = ReachState
+					minAltitude = @/altitude * 1000
+					hideChildren = true
+					disableOnStateChange = true
+					title = Reach an altitude of at least @/altitude km
+				}
+				PARAMETER {
+					name = HasCommPayload
+					type = HasResource
+					resource = CommPayload
+					minQuantity = @/payload-0.1
+					title = Have a CommPayload of at least @/payload units on the craft
+					hideChildren = true
+					completeInSequence = true
+					disableOnStateChange = true
+				}
+				PARAMETER {
+					name = ExperimentRunning
+					type = ExperimentRunning
+					title = Run a small biological experiment (above @/altitude km)
+					experiment = RP0bioScan1
+					completeInSequence = true
+					hideChildren = true
+				}
 			}
+			/// Disabled due to display issues - forcing the experiment means that you do not get science if you do not recover anyway
 			///PARAMETER {
-			///	name = ExperimentRunning
-			///	type = ExperimentRunning
-			///	experiment = bioScan1
+			///	name = HasBiologicalSample
+			///	type = PartValidation
+			///	hidden = true
+			///	hideChildren = true
+			///	FILTER {
+			///		MODULE {
+			///			name = Experiment
+			///			experiment_id = RP0bioScan1
+			///		}
+			///	}
 			///	completeInSequence = true
 			///	disableOnStateChange = true
 			///}
@@ -336,20 +401,8 @@ CONTRACT_TYPE {
 				name = ReturnHome
 				type = ReturnHome
 				targetBody = HomeWorld()
+				title = Return home safely
 				hideChildren = true
-				completeInSequence = true
-			}
-			PARAMETER {
-				name = HasBiologicalSample
-				type = PartValidation
-				hidden = true
-				hideChildren = true
-				FILTER {
-					MODULE {
-						name = Experiment
-						experiment_id = bioScan1
-					}
-				}
 				completeInSequence = true
 			}
 		}
@@ -396,23 +449,50 @@ CONTRACT_TYPE {
 				hideChildren = true
 			}
 			PARAMETER {
-				name = SpaceAltitude
-				type = ReachState
-				minAltitude = @/altitude * 1000
-				disableOnStateChange = true
-			}
-			PARAMETER {
-				name = HasCommPayload
-				type = HasResource
-				resource = CommPayload
-				minQuantity = @/payload-0.1
+				name = PayloadMissionParameters
+				type = VesselParameterGroup		
+				title = Reach @/altitude km with the payload and run experiment for 60 seconds
+				duration = 1m
 				hideChildren = true
-				completeInSequence = true
+				PARAMETER {
+					name = SpaceAltitude
+					type = ReachState
+					minAltitude = @/altitude * 1000
+					hideChildren = true
+					disableOnStateChange = true
+					title = Reach an altitude of at least @/altitude km
+				}
+				PARAMETER {
+					name = HasCommPayload
+					type = HasResource
+					resource = CommPayload
+					minQuantity = @/payload-0.1
+					title = Have a CommPayload of at least @/payload units on the craft
+					hideChildren = true
+					completeInSequence = true
+					disableOnStateChange = true
+				}
+				PARAMETER {
+					name = ExperimentRunning
+					type = ExperimentRunning
+					title = Run a small biological experiment (above @/altitude km)
+					experiment = RP0bioScan1
+					completeInSequence = true
+					hideChildren = true
+				}
 			}
+			/// Disabled due to display issues - forcing the experiment means that you do not get science if you do not recover anyway
 			///PARAMETER {
-			///	name = ExperimentRunning
-			///	type = ExperimentRunning
-			///	experiment = bioScan1
+			///	name = HasBiologicalSample
+			///	type = PartValidation
+			///	hidden = true
+			///	hideChildren = true
+			///	FILTER {
+			///		MODULE {
+			///			name = Experiment
+			///			experiment_id = RP0bioScan1
+			///		}
+			///	}
 			///	completeInSequence = true
 			///	disableOnStateChange = true
 			///}
@@ -422,19 +502,6 @@ CONTRACT_TYPE {
 				targetBody = HomeWorld()
 				title = Return home safely
 				hideChildren = true
-				completeInSequence = true
-			}
-			PARAMETER {
-				name = HasBiologicalSample
-				type = PartValidation
-				hidden = true
-				hideChildren = true
-				FILTER {
-					MODULE {
-						name = Experiment
-						experiment_id = bioScan1
-					}
-				}
 				completeInSequence = true
 			}
 		}


### PR DESCRIPTION
Fixed First Sounding Rocket contract so that altitude-related items are inside a VesselParameterGroup so that it can be retained on reentry.

Fixed the Low Small Bio campaign using the proper bio experiment_id (RP0bioScan1), making sure items are in proper VesselParameterGroup, and enabling the experiment running for 60 seconds duration as per the written requirement.

The PartValidation had display issues when inside the 4 launches sub-section, even with hidden and hideChildren it still displayed the name and experiment_id in the contract window for all 4. Since not recovering the Bio Sample prevents you from getting the science, and the main contract section shows the requirement, it can work until a proper display solution is found.